### PR TITLE
Add error handling when specified ssh-key name

### DIFF
--- a/nifcloud/nifcloud.go
+++ b/nifcloud/nifcloud.go
@@ -699,6 +699,9 @@ func (d *Driver) createKeyPair() error {
 	})
 
 	if err != nil {
+		if strings.Contains(err.Error(), "Client.InvalidParameterDuplicate.KeyName") {
+			return nil
+		}
 		return err
 	}
 

--- a/nifcloud/nifcloud.go
+++ b/nifcloud/nifcloud.go
@@ -699,10 +699,11 @@ func (d *Driver) createKeyPair() error {
 	})
 
 	if err != nil {
-		if strings.Contains(err.Error(), "Client.InvalidParameterDuplicate.KeyName") {
-			return nil
+		awsErr, _ := err.(awserr.Error)
+
+		if awsErr.Code() != "Client.InvalidParameterDuplicate.KeyName" {
+			return fmt.Errorf("Error CreateKeyPair: %s", err)
 		}
-		return err
 	}
 
 	// TODO wait


### PR DESCRIPTION
インスタンス作成時に ssh key 名を指定したときに，ssh key がすでに存在するケースで
インスタンス作成もエラーになるので，エラーハンドリングを追加しました．